### PR TITLE
patch/mp4

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,4 @@ All supported image and video formats can be found in the table below:
 - https://www.fileformat.info/format/tiff/egff.htm#TIFF.FO
 - http://netpbm.sourceforge.net/doc/#formats
 - https://www.garykessler.net/library/file_sigs.html
+- https://github.com/sannies/mp4parser/blob/c869d076e9cd42aba5a3e35d88827610dec6ca15/examples/src/main/java/com/google/code/mp4parser/example/GetHeight.java

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "leather",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "leather",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "license": "MIT",
             "devDependencies": {
                 "ava": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "leather",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "A pure JS library for extracting image/video attributes such as width, height, size, and mime type",
     "author": "Sidney Liebrand",
     "license": "MIT",

--- a/src/extractors/mp4.js
+++ b/src/extractors/mp4.js
@@ -7,23 +7,67 @@ const MIME_TYPES = {
 
 export function attributes(input) {
     const stream = lazystream(input);
-    const startIndex = stream.indexOf(Buffer.from('tkhd'));
     const type = stream.skip(4).take(8).toString('hex');
     const mime = MIME_TYPES[type] || 'video/mp4';
 
-    const result = {
-        width: 0,
-        height: 0,
-        size: stream.size(),
-        mime,
-    };
+    const result = Object.assign(v2(stream) ?? {}, {size: stream.size(), mime});
 
-    if (startIndex !== -1) {
-        result.width = stream.goto(startIndex).skip(78).takeUInt32BE();
-        result.height = stream.takeUInt32BE();
+    if (!Number.isInteger(result.width) || !Number.isInteger(result.height)) {
+        stream.goto(0);
+
+        const startIndex = stream.indexOf(Buffer.from('tkhd'));
+
+        if (startIndex === -1) {
+            result.width = 0;
+            result.height = 0;
+        } else {
+            result.width = stream.goto(startIndex).skip(78).takeUInt32BE();
+            result.height = stream.takeUInt32BE();
+        }
     }
 
     stream.close();
 
     return result;
+}
+
+const containers = ['moov', 'mdia', 'trak'];
+
+function v2(stream, lastTkhd) {
+    while (stream.more()) {
+        const size = stream.takeUInt32BE();
+        const header = stream.take(4).toString();
+
+        if (containers.includes(header)) {
+            const result = v2(stream, lastTkhd);
+
+            if (result) return result;
+        } else if (header === 'tkhd') {
+            const pos = stream.position();
+            lastTkhd = stream.take(size - 8);
+
+            stream.goto(pos);
+        } else if (header === 'hdlr') {
+            const pos = stream.position();
+            const hdlr = stream.take(size - 8);
+
+            if (
+                hdlr[8] == 0x76 &&
+                hdlr[9] == 0x69 &&
+                hdlr[10] == 0x64 &&
+                hdlr[11] == 0x65
+            ) {
+                const width =
+                    lastTkhd.readUInt32BE(lastTkhd.length - 8) / 65536;
+                const height =
+                    lastTkhd.readUInt32BE(lastTkhd.length - 4) / 65536;
+
+                return {width, height};
+            }
+
+            stream.goto(pos);
+        }
+
+        stream.skip(size);
+    }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -25,7 +25,7 @@ const BYTE_INFO = new Map();
     BYTE_INFO.set(/^52494646/i,                           'avi');
     BYTE_INFO.set(/^.{8}1[12]af/i,                        'fli');
     BYTE_INFO.set(/^464c56/i,                             'flv');
-    BYTE_INFO.set(/^.{6}(?:20|14|6674)/i,                 'mp4');
+    BYTE_INFO.set(/^.{6}(?:20|1[4c]|6674)/i,              'mp4');
     BYTE_INFO.set(/^4f676753/i,                           'ogv');
     BYTE_INFO.set(/^1a45dfa3(?:01|9f|a3)/i,               'webm');
     BYTE_INFO.set(/^50(?:3[1-7]|46)/i,                    'pnm');


### PR DESCRIPTION
- Identify mp4 v2 files as video/mp4
- Fix: mp4 extractor handles more cases (#9, v1 vs v2)
- 2.1.1
