### PR TITLE
patch/reduce system reads

### DIFF
--- a/src/extractors/avi.js
+++ b/src/extractors/avi.js
@@ -1,4 +1,4 @@
-import {lazystream, roundToPrecision} from '../util.js';
+import {lazystream} from '../util.js';
 
 export function attributes(input) {
     const stream = lazystream(input);

--- a/src/extractors/fit.js
+++ b/src/extractors/fit.js
@@ -9,29 +9,24 @@ export function attributes(input) {
         mime: 'image/fits',
     };
 
-    let offset = 0;
-
     while (stream.more()) {
-        const label = stream
-            .goto(offset * 80)
-            .takeUntil(0x20)
-            .toString();
+        const header = stream.take(30);
+        const label = header.subarray(0, 8);
 
-        if (label === 'NAXIS1' || label === 'NAXIS2') {
-            const property = label === 'NAXIS1' ? 'width' : 'height';
-            result[property] = parseInt(
-                stream
-                    .goto(offset * 80)
-                    .skip(24)
-                    .take(8)
-                    .toString()
-                    .trim()
-            );
+        if (label.includes('NAXIS1')) {
+            result.width = parseInt(header.subarray(22, 30));
+        } else if (label.includes('NAXIS2')) {
+            result.height = parseInt(header.subarray(22, 30));
 
-            if (result.width !== 0 && result.height !== 0) break;
+            break;
+        } else if (
+            label.includes('NAXIS') &&
+            parseInt(header.subarray(22, 30)) < 2
+        ) {
+            break;
         }
 
-        offset += 1;
+        stream.skip(50);
     }
 
     stream.close();

--- a/src/extractors/hdr.js
+++ b/src/extractors/hdr.js
@@ -9,21 +9,19 @@ export function attributes(input) {
         mime: 'image/vnd.radiance',
     };
 
-    while (stream.more()) {
-        const line = stream.takeLine().toString();
+    for (const chunk of stream.overlappingChunks(64)) {
+        const content = chunk.buffer.toString();
+        const matches = content.match(/[-+][xy]\s+\d+\s/gi);
 
-        if (line.match(/[-+][xy]/i)) {
-            const parts = line
-                .split(' ')
-                .map((part) => part.replace(/[^a-z0-9]/gi, '').toUpperCase());
+        if (matches?.length === 2) {
+            for (const match of matches) {
+                const cleanMatch = match.toLowerCase().trim().slice(1);
+                const [axis, stringSize] = cleanMatch.split(/\s+/i);
 
-            if (parts[0] === 'Y') {
-                result.width = parseInt(parts[3], 10);
-                result.height = parseInt(parts[1], 10);
-            } else {
-                result.width = parseInt(parts[1], 10);
-                result.height = parseInt(parts[3], 10);
+                if (axis === 'x') result.width = parseInt(stringSize);
+                if (axis === 'y') result.height = parseInt(stringSize);
             }
+
             break;
         }
     }

--- a/src/extractors/j2c.js
+++ b/src/extractors/j2c.js
@@ -2,8 +2,9 @@ import {lazystream} from '../util.js';
 
 export function attributes(input) {
     const stream = lazystream(input);
-    const height = stream.skip(48).takeUInt32BE();
-    const width = stream.takeUInt32BE();
+    const dimensions = stream.skip(48).take(8);
+    const height = dimensions.readUInt32BE();
+    const width = dimensions.readUInt32BE(4);
     const result = {width, height, size: stream.size(), mime: 'image/jp2'};
 
     stream.close();

--- a/src/extractors/jpg.js
+++ b/src/extractors/jpg.js
@@ -12,14 +12,18 @@ export function attributes(input) {
     stream.skip(4);
 
     while (stream.more()) {
-        const size = stream.takeUInt16BE();
-        const mark = stream.skip(size - 2).takeUInt8();
-        const next = stream.takeUInt8();
+        stream.skip(stream.takeUInt16BE() - 2);
+
+        const header = stream.take(2);
+        const mark = header.readUInt8();
+        const next = header.readUInt8(1);
 
         if (mark !== 0xff) break;
         if (next === 0xc0 || next === 0xc1 || next === 0xc2) {
-            result.height = stream.skip(3).takeUInt16BE();
-            result.width = stream.takeUInt16BE();
+            const dimensions = stream.skip(3).take(4);
+
+            result.height = dimensions.readUInt16BE();
+            result.width = dimensions.readUInt16BE(2);
 
             break;
         }

--- a/src/extractors/png.js
+++ b/src/extractors/png.js
@@ -2,34 +2,21 @@ import {lazystream} from '../util.js';
 
 export function attributes(input) {
     const stream = lazystream(input);
-    const isMNG = stream.take(4).includes('MNG');
-    const isFried = stream.skip(8).take(4).includes('CgBI');
+    const header = stream.take(16);
 
-    if (isFried) stream.skip(16);
+    if (header.includes('CgBI')) stream.skip(16);
 
-    const result = {
-        width: stream.takeUInt32BE(),
-        height: stream.takeUInt32BE(),
-        size: stream.size(),
-        mime: isMNG
-            ? 'video/x-mng'
-            : isAPNG(stream)
-            ? 'image/apng'
-            : 'image/png',
-    };
+    const dimensions = stream.take(8);
+    const width = dimensions.readUInt32BE();
+    const height = dimensions.readUInt32BE(4);
+    const mime = header.includes('MNG')
+        ? 'video/x-mng'
+        : stream.take(128).includes('acTL')
+        ? 'image/apng'
+        : 'image/png';
+    const result = {width, height, size: stream.size(), mime};
 
     stream.close();
-
-    return result;
-}
-
-function isAPNG(stream) {
-    const position = stream.position();
-    const result = [256, 512, 1024].some((size) =>
-        stream.take(size).includes('acTL')
-    );
-
-    stream.goto(position);
 
     return result;
 }

--- a/src/extractors/xpm.js
+++ b/src/extractors/xpm.js
@@ -9,14 +9,18 @@ export function attributes(input) {
         mime: 'image/x-xpixmap',
     };
 
-    const startIndex = stream.indexOf(Buffer.from('{\n"'));
+    const target = '[] = {\n';
+    const startIndex = stream.indexOf(target);
+    const [widthString, heightString] = stream
+        .skip(startIndex + target.length)
+        .takeLine()
+        .toString()
+        .replace(/[^\d\s]/g, '')
+        .split(/\s+/);
 
-    if (startIndex !== -1) {
-        result.width = parseInt(
-            stream.goto(startIndex).skip(3).takeUntil(0x20).toString(),
-            10
-        );
-        result.height = parseInt(stream.skip(1).takeUntil(0x20).toString(), 10);
+    if (widthString && heightString) {
+        result.width = parseInt(widthString);
+        result.height = parseInt(heightString);
     }
 
     stream.close();

--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,7 @@ const BYTE_INFO = new Map();
     BYTE_INFO.set(/^464c56/i,                             'flv');
     BYTE_INFO.set(/^.{6}(?:20|1[4c]|6674)/i,              'mp4');
     BYTE_INFO.set(/^4f676753/i,                           'ogv');
-    BYTE_INFO.set(/^1a45dfa3(?:01|9f|a3)/i,               'webm');
+    BYTE_INFO.set(/^1a45dfa3/i,                           'webm');
     BYTE_INFO.set(/^50(?:3[1-7]|46)/i,                    'pnm');
     BYTE_INFO.set(/^3026b2/i,                             'wmv');
 }


### PR DESCRIPTION
- Remove unused import from extractors/avi.js
- Clean up extractors/xpm.js
- Reduce reads from 100s down to 10s in extractors/webm.js
- Reduce reads from 100s down to 10s in extractors/svg.js
- Clean up extractors/pnm.js
- Clean up and slightly reduce reads in extractors/png.js
- Clean up and slightly reduce reads in extractors/mp4.js
- Slightly reduce reads in extractors/jpg.js
- Slightly reduce reads in extractors/j2c.js
- Clean up extractors/hdr.js
- Clean up and reduce reads in extractors/fit.js
- Make webm magic byte regular expression less specific
- Add `readVint` and `stream.overlappingChunks` utilities, optimize `stream.indexOf`
