### PR TITLE
patch/rename exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,32 +60,32 @@ yarn add leather
 After [installing the package](#installation), it can be imported using commonjs:
 
 ```javascript
-const {attributes} = require('leather');
+const {readMediaAttributes} = require('leather');
 ```
 
 Or using ES modules:
 
 ```javascript
-import {attributes} from 'leather';
+import {readMediaAttributes} from 'leather';
 ```
 
 Then, it can be called on [supported image and video formats](#supported-formats):
 
 ```javascript
-console.log(attributes('cat.jpg'));
+console.log(readMediaAttributes('cat.jpg'));
 
 // => {width: 200, height: 200, size: 40000, mime: 'image/jpeg'}
 ```
 
 ## Buffer support
 
-Starting from version **2.1.0**, all `attributes` methods also accept `Buffer`
+Starting from version **2.1.0**, all `readMediaAttributes` methods also accept `Buffer`
 instances in addition to file paths:
 
 ```javascript
 const buffer = fs.readFileSync('cat.png');
 
-console.log(attributes(buffer));
+console.log(readMediaAttributes(buffer));
 
 // => {width: 200, height: 200, size: 40000, mime: 'image/jpeg'}
 ```
@@ -102,10 +102,10 @@ require only the extractors you need, e.g. for jpg/jpeg using commonjs:
 
 ```javascript
 const {readFileSync} = require('fs');
-const {attributes} = require('leather/extractors/jpg');
+const {readMediaAttributes} = require('leather/extractors/jpg');
 
-console.log(attributes('cat.jpg'));
-console.log(attributes(readFileSync('cat.jpg')));
+console.log(readMediaAttributes('cat.jpg'));
+console.log(readMediaAttributes(readFileSync('cat.jpg')));
 
 // => {width: 200, height: 200, size: 40000, mime: 'image/jpeg'}
 ```
@@ -114,10 +114,10 @@ Or using ES modules:
 
 ```javascript
 import {readFileSync} from 'fs';
-import {attributes} from 'leather/extractors/jpg';
+import {readMediaAttributes} from 'leather/extractors/jpg';
 
-console.log(attributes('cat.jpg'));
-console.log(attributes(readFileSync('cat.jpg')));
+console.log(readMediaAttributes('cat.jpg'));
+console.log(readMediaAttributes(readFileSync('cat.jpg')));
 
 // => {width: 200, height: 200, size: 40000, mime: 'image/jpeg'}
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "leather",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "leather",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "license": "MIT",
             "devDependencies": {
                 "ava": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "leather",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "description": "A pure JS library for extracting image/video attributes such as width, height, size, and mime type",
     "author": "Sidney Liebrand",
     "license": "MIT",

--- a/src/extractors/avi.js
+++ b/src/extractors/avi.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const width = stream.skip(64).takeUInt32LE();
     const height = stream.takeUInt32LE();

--- a/src/extractors/bmp.js
+++ b/src/extractors/bmp.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const width = stream.skip(18).takeUInt16LE();
     const height = Math.abs(stream.skip(2).takeUInt16LE());

--- a/src/extractors/cel.js
+++ b/src/extractors/cel.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: stream.goto(8).takeUInt16LE(),

--- a/src/extractors/dds.js
+++ b/src/extractors/dds.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const height = stream.skip(12).takeUInt32LE();
     const width = stream.takeUInt32LE();

--- a/src/extractors/fit.js
+++ b/src/extractors/fit.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: 0,

--- a/src/extractors/fli.js
+++ b/src/extractors/fli.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const width = stream.skip(8).takeUInt16LE();
     const height = stream.takeUInt16LE();

--- a/src/extractors/flv.js
+++ b/src/extractors/flv.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: 0,

--- a/src/extractors/gif.js
+++ b/src/extractors/gif.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const width = stream.skip(6).takeUInt16LE();
     const height = stream.takeUInt16LE();

--- a/src/extractors/hdr.js
+++ b/src/extractors/hdr.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: 0,

--- a/src/extractors/icns.js
+++ b/src/extractors/icns.js
@@ -34,7 +34,7 @@ const TYPE_SIZES = {
     ic10: 1024,
 };
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const type = stream.skip(8).take(4).toString();
     const size = TYPE_SIZES[type] || 0;

--- a/src/extractors/ico.js
+++ b/src/extractors/ico.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const [width, height] = stream.skip(6).take(2);
     const result = {

--- a/src/extractors/j2c.js
+++ b/src/extractors/j2c.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const dimensions = stream.skip(48).take(8);
     const height = dimensions.readUInt32BE();

--- a/src/extractors/jpg.js
+++ b/src/extractors/jpg.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: 0,

--- a/src/extractors/ktx.js
+++ b/src/extractors/ktx.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const width = stream.skip(36).takeUInt32LE();
     const height = stream.takeUInt32LE();

--- a/src/extractors/mp4.js
+++ b/src/extractors/mp4.js
@@ -5,7 +5,7 @@ const MIME_TYPES = {
     ['6674797071742020']: 'video/quicktime',
 };
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const size = stream.size();
     const type = stream.skip(4).take(8).toString('hex');

--- a/src/extractors/ogv.js
+++ b/src/extractors/ogv.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const width = stream.skip(42).takeUIntBE(3);
     const height = stream.takeUIntBE(3);

--- a/src/extractors/png.js
+++ b/src/extractors/png.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const header = stream.take(16);
 

--- a/src/extractors/pnm.js
+++ b/src/extractors/pnm.js
@@ -11,7 +11,7 @@ const MIME_TYPES = {
     ['P7']: 'image/x-portable-arbitrarymap',
 };
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const type = stream.take(3).toString().trim();
     const attrs = type === 'P7' ? pam(stream) : pnm(stream);

--- a/src/extractors/psd.js
+++ b/src/extractors/psd.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const height = stream.skip(14).takeUInt32BE();
     const width = stream.takeUInt32BE();

--- a/src/extractors/svg.js
+++ b/src/extractors/svg.js
@@ -13,7 +13,7 @@ const UNITS = {
     rem: 16,
 };
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     let attrQuote = null;
     const stream = lazystream(input);
     const found = {};

--- a/src/extractors/tiff.js
+++ b/src/extractors/tiff.js
@@ -1,10 +1,12 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const isBigEndian =
         Buffer.compare(stream.take(2), Buffer.from([0x4d, 0x4d])) === 0;
-    const attrs = isBigEndian ? attributesBE(stream) : attributesLE(stream);
+    const attrs = isBigEndian
+        ? readBigEndian(stream)
+        : readLittleEndian(stream);
     const result = {...attrs, size: stream.size(), mime: 'image/tiff'};
 
     stream.close();
@@ -12,7 +14,7 @@ export function attributes(input) {
     return result;
 }
 
-function attributesBE(stream) {
+function readBigEndian(stream) {
     const result = {width: 0, height: 0};
     const ifdIndex = stream.skip(2).takeUInt32BE();
 
@@ -35,7 +37,7 @@ function attributesBE(stream) {
     return result;
 }
 
-function attributesLE(stream) {
+function readLittleEndian(stream) {
     const result = {width: 0, height: 0};
     const ifdIndex = stream.skip(2).takeUInt32LE();
 

--- a/src/extractors/webm.js
+++ b/src/extractors/webm.js
@@ -1,6 +1,6 @@
 import {lazystream, readVint} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const byte = stream.goto(4).take()[0];
     const mime = byte === 0xa3 ? 'video/x-matroska' : 'video/webm';

--- a/src/extractors/webp.js
+++ b/src/extractors/webp.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const header = stream.skip(12).take(4).toString();
     const isLossless = stream.skip(4).take()[0] === 0x2f;

--- a/src/extractors/wmv.js
+++ b/src/extractors/wmv.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: stream.goto(358).takeUInt32LE(),

--- a/src/extractors/xbm.js
+++ b/src/extractors/xbm.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const firstLine = stream.takeLine().toString();
     const secondLine = stream.takeLine().toString();

--- a/src/extractors/xpm.js
+++ b/src/extractors/xpm.js
@@ -1,6 +1,6 @@
 import {lazystream} from '../util.js';
 
-export function attributes(input) {
+export function readMediaAttributes(input) {
     const stream = lazystream(input);
     const result = {
         width: 0,

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,30 @@
 import {lazystream} from './util.js';
-import {attributes as bmp} from './extractors/bmp.js';
-import {attributes as dds} from './extractors/dds.js';
-import {attributes as gif} from './extractors/gif.js';
-import {attributes as icns} from './extractors/icns.js';
-import {attributes as ico} from './extractors/ico.js';
-import {attributes as j2c} from './extractors/j2c.js';
-import {attributes as jpg} from './extractors/jpg.js';
-import {attributes as ktx} from './extractors/ktx.js';
-import {attributes as png} from './extractors/png.js';
-import {attributes as pnm} from './extractors/pnm.js';
-import {attributes as psd} from './extractors/psd.js';
-import {attributes as svg} from './extractors/svg.js';
-import {attributes as tiff} from './extractors/tiff.js';
-import {attributes as webp} from './extractors/webp.js';
-import {attributes as xpm} from './extractors/xpm.js';
-import {attributes as xbm} from './extractors/xbm.js';
-import {attributes as fit} from './extractors/fit.js';
-import {attributes as cel} from './extractors/cel.js';
-import {attributes as hdr} from './extractors/hdr.js';
-import {attributes as avi} from './extractors/avi.js';
-import {attributes as fli} from './extractors/fli.js';
-import {attributes as flv} from './extractors/flv.js';
-import {attributes as ogv} from './extractors/ogv.js';
-import {attributes as mp4} from './extractors/mp4.js';
-import {attributes as webm} from './extractors/webm.js';
-import {attributes as wmv} from './extractors/wmv.js';
+import {readMediaAttributes as bmp} from './extractors/bmp.js';
+import {readMediaAttributes as dds} from './extractors/dds.js';
+import {readMediaAttributes as gif} from './extractors/gif.js';
+import {readMediaAttributes as icns} from './extractors/icns.js';
+import {readMediaAttributes as ico} from './extractors/ico.js';
+import {readMediaAttributes as j2c} from './extractors/j2c.js';
+import {readMediaAttributes as jpg} from './extractors/jpg.js';
+import {readMediaAttributes as ktx} from './extractors/ktx.js';
+import {readMediaAttributes as png} from './extractors/png.js';
+import {readMediaAttributes as pnm} from './extractors/pnm.js';
+import {readMediaAttributes as psd} from './extractors/psd.js';
+import {readMediaAttributes as svg} from './extractors/svg.js';
+import {readMediaAttributes as tiff} from './extractors/tiff.js';
+import {readMediaAttributes as webp} from './extractors/webp.js';
+import {readMediaAttributes as xpm} from './extractors/xpm.js';
+import {readMediaAttributes as xbm} from './extractors/xbm.js';
+import {readMediaAttributes as fit} from './extractors/fit.js';
+import {readMediaAttributes as cel} from './extractors/cel.js';
+import {readMediaAttributes as hdr} from './extractors/hdr.js';
+import {readMediaAttributes as avi} from './extractors/avi.js';
+import {readMediaAttributes as fli} from './extractors/fli.js';
+import {readMediaAttributes as flv} from './extractors/flv.js';
+import {readMediaAttributes as ogv} from './extractors/ogv.js';
+import {readMediaAttributes as mp4} from './extractors/mp4.js';
+import {readMediaAttributes as webm} from './extractors/webm.js';
+import {readMediaAttributes as wmv} from './extractors/wmv.js';
 
 // extractor mapping table based on `lazystream(file).identifier()`
 const extractors = {
@@ -56,7 +56,7 @@ const extractors = {
     wmv,
 };
 
-export function attributes(file) {
+export function readMediaAttributes(file) {
     const stream = lazystream(file);
     const result = {width: 0, height: 0, size: 0, mime: undefined};
     const extract = extractors[stream.identifier()];

--- a/test/extractors.mjs
+++ b/test/extractors.mjs
@@ -1,11 +1,13 @@
 import test from 'ava';
-import {attributes} from '../src/index.js';
+import {readMediaAttributes} from '../src/index.js';
 import {readFileSync} from 'fs';
 
 test('jpg', (t) => {
     const expected = {width: 1, height: 2, size: 1229, mime: 'image/jpeg'};
-    const pathAttributes = attributes('test/files/example.jpg');
-    const bufferAttributes = attributes(readFileSync('test/files/example.jpg'));
+    const pathAttributes = readMediaAttributes('test/files/example.jpg');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.jpg')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -13,8 +15,10 @@ test('jpg', (t) => {
 
 test('j2c', (t) => {
     const expected = {width: 1, height: 2, size: 282, mime: 'image/jp2'};
-    const pathAttributes = attributes('test/files/example.j2c');
-    const bufferAttributes = attributes(readFileSync('test/files/example.j2c'));
+    const pathAttributes = readMediaAttributes('test/files/example.j2c');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.j2c')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -22,8 +26,10 @@ test('j2c', (t) => {
 
 test('jp2', (t) => {
     const expected = {width: 1, height: 2, size: 282, mime: 'image/jp2'};
-    const pathAttributes = attributes('test/files/example.jp2');
-    const bufferAttributes = attributes(readFileSync('test/files/example.jp2'));
+    const pathAttributes = readMediaAttributes('test/files/example.jp2');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.jp2')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -31,8 +37,10 @@ test('jp2', (t) => {
 
 test('png', (t) => {
     const expected = {width: 1, height: 2, size: 550, mime: 'image/png'};
-    const pathAttributes = attributes('test/files/example.png');
-    const bufferAttributes = attributes(readFileSync('test/files/example.png'));
+    const pathAttributes = readMediaAttributes('test/files/example.png');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.png')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -40,8 +48,8 @@ test('png', (t) => {
 
 test('apng', (t) => {
     const expected = {width: 100, height: 100, size: 63435, mime: 'image/apng'};
-    const pathAttributes = attributes('test/files/example.apng');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.apng');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.apng')
     );
 
@@ -51,8 +59,8 @@ test('apng', (t) => {
 
 test('png (fried)', (t) => {
     const expected = {width: 128, height: 68, size: 3099, mime: 'image/png'};
-    const pathAttributes = attributes('test/files/example.fried.png');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.fried.png');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.fried.png')
     );
 
@@ -62,8 +70,10 @@ test('png (fried)', (t) => {
 
 test('svg', (t) => {
     const expected = {width: 1, height: 2, size: 377, mime: 'image/svg+xml'};
-    const pathAttributes = attributes('test/files/example.svg');
-    const bufferAttributes = attributes(readFileSync('test/files/example.svg'));
+    const pathAttributes = readMediaAttributes('test/files/example.svg');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.svg')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -71,8 +81,10 @@ test('svg', (t) => {
 
 test('gif', (t) => {
     const expected = {width: 1, height: 2, size: 56, mime: 'image/gif'};
-    const pathAttributes = attributes('test/files/example.gif');
-    const bufferAttributes = attributes(readFileSync('test/files/example.gif'));
+    const pathAttributes = readMediaAttributes('test/files/example.gif');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.gif')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -85,8 +97,10 @@ test('ico', (t) => {
         size: 86,
         mime: 'image/vnd.microsoft.icon',
     };
-    const pathAttributes = attributes('test/files/example.ico');
-    const bufferAttributes = attributes(readFileSync('test/files/example.ico'));
+    const pathAttributes = readMediaAttributes('test/files/example.ico');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.ico')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -99,8 +113,10 @@ test('cur', (t) => {
         size: 78,
         mime: 'image/vnd.microsoft.icon',
     };
-    const pathAttributes = attributes('test/files/example.cur');
-    const bufferAttributes = attributes(readFileSync('test/files/example.cur'));
+    const pathAttributes = readMediaAttributes('test/files/example.cur');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.cur')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -108,8 +124,10 @@ test('cur', (t) => {
 
 test('bmp', (t) => {
     const expected = {width: 1, height: 2, size: 130, mime: 'image/bmp'};
-    const pathAttributes = attributes('test/files/example.bmp');
-    const bufferAttributes = attributes(readFileSync('test/files/example.bmp'));
+    const pathAttributes = readMediaAttributes('test/files/example.bmp');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.bmp')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -122,8 +140,10 @@ test('psd', (t) => {
         size: 954,
         mime: 'image/vnd.adobe.photoshop',
     };
-    const pathAttributes = attributes('test/files/example.psd');
-    const bufferAttributes = attributes(readFileSync('test/files/example.psd'));
+    const pathAttributes = readMediaAttributes('test/files/example.psd');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.psd')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -131,8 +151,10 @@ test('psd', (t) => {
 
 test('dds', (t) => {
     const expected = {width: 1, height: 2, size: 134, mime: 'image/vnd.ms-dds'};
-    const pathAttributes = attributes('test/files/example.dds');
-    const bufferAttributes = attributes(readFileSync('test/files/example.dds'));
+    const pathAttributes = readMediaAttributes('test/files/example.dds');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.dds')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -140,8 +162,10 @@ test('dds', (t) => {
 
 test('ktx', (t) => {
     const expected = {width: 1, height: 2, size: 104, mime: 'image/ktx'};
-    const pathAttributes = attributes('test/files/example.ktx');
-    const bufferAttributes = attributes(readFileSync('test/files/example.ktx'));
+    const pathAttributes = readMediaAttributes('test/files/example.ktx');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.ktx')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -149,8 +173,8 @@ test('ktx', (t) => {
 
 test('webp', (t) => {
     const expected = {width: 1, height: 2, size: 44, mime: 'image/webp'};
-    const pathAttributes = attributes('test/files/example.webp');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.webp');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.webp')
     );
 
@@ -160,8 +184,10 @@ test('webp', (t) => {
 
 test('webp (animated)', (t) => {
     const expected = {width: 400, height: 400, size: 37342, mime: 'image/webp'};
-    const pathAttributes = attributes('test/files/example.animated.webp');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes(
+        'test/files/example.animated.webp'
+    );
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.animated.webp')
     );
 
@@ -171,8 +197,10 @@ test('webp (animated)', (t) => {
 
 test('webp (lossless)', (t) => {
     const expected = {width: 1, height: 2, size: 38, mime: 'image/webp'};
-    const pathAttributes = attributes('test/files/example.lossless.webp');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes(
+        'test/files/example.lossless.webp'
+    );
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.lossless.webp')
     );
 
@@ -182,8 +210,10 @@ test('webp (lossless)', (t) => {
 
 test('webp (extended)', (t) => {
     const expected = {width: 1, height: 2, size: 2256, mime: 'image/webp'};
-    const pathAttributes = attributes('test/files/example.extended.webp');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes(
+        'test/files/example.extended.webp'
+    );
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.extended.webp')
     );
 
@@ -193,8 +223,8 @@ test('webp (extended)', (t) => {
 
 test('icns', (t) => {
     const expected = {width: 16, height: 16, size: 39985, mime: 'image/x-icns'};
-    const pathAttributes = attributes('test/files/example.icns');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.icns');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.icns')
     );
 
@@ -209,8 +239,10 @@ test('pfm', (t) => {
         size: 36,
         mime: 'application/x-font-type1',
     };
-    const pathAttributes = attributes('test/files/example.pfm');
-    const bufferAttributes = attributes(readFileSync('test/files/example.pfm'));
+    const pathAttributes = readMediaAttributes('test/files/example.pfm');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.pfm')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -223,8 +255,10 @@ test('pam', (t) => {
         size: 84,
         mime: 'image/x-portable-arbitrarymap',
     };
-    const pathAttributes = attributes('test/files/example.pam');
-    const bufferAttributes = attributes(readFileSync('test/files/example.pam'));
+    const pathAttributes = readMediaAttributes('test/files/example.pam');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.pam')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -237,8 +271,10 @@ test('pbm', (t) => {
         size: 55,
         mime: 'image/x-portable-bitmap',
     };
-    const pathAttributes = attributes('test/files/example.pbm');
-    const bufferAttributes = attributes(readFileSync('test/files/example.pbm'));
+    const pathAttributes = readMediaAttributes('test/files/example.pbm');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.pbm')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -251,8 +287,8 @@ test('pbm (ascii)', (t) => {
         size: 55,
         mime: 'image/x-portable-bitmap',
     };
-    const pathAttributes = attributes('test/files/example.ascii.pbm');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.ascii.pbm');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.ascii.pbm')
     );
 
@@ -267,8 +303,10 @@ test('pgm', (t) => {
         size: 59,
         mime: 'image/x-portable-graymap',
     };
-    const pathAttributes = attributes('test/files/example.pgm');
-    const bufferAttributes = attributes(readFileSync('test/files/example.pgm'));
+    const pathAttributes = readMediaAttributes('test/files/example.pgm');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.pgm')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -281,8 +319,8 @@ test('pgm (ascii)', (t) => {
         size: 65,
         mime: 'image/x-portable-graymap',
     };
-    const pathAttributes = attributes('test/files/example.ascii.pgm');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.ascii.pgm');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.ascii.pgm')
     );
 
@@ -297,8 +335,10 @@ test('ppm', (t) => {
         size: 63,
         mime: 'image/x-portable-pixmap',
     };
-    const pathAttributes = attributes('test/files/example.ppm');
-    const bufferAttributes = attributes(readFileSync('test/files/example.ppm'));
+    const pathAttributes = readMediaAttributes('test/files/example.ppm');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.ppm')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -311,8 +351,8 @@ test('ppm (ascii)', (t) => {
         size: 81,
         mime: 'image/x-portable-pixmap',
     };
-    const pathAttributes = attributes('test/files/example.ascii.ppm');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.ascii.ppm');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.ascii.ppm')
     );
 
@@ -322,8 +362,8 @@ test('ppm (ascii)', (t) => {
 
 test('webm', (t) => {
     const expected = {width: 2, height: 4, size: 765, mime: 'video/webm'};
-    const pathAttributes = attributes('test/files/example.webm');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.webm');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.webm')
     );
 
@@ -333,8 +373,10 @@ test('webm', (t) => {
 
 test('webm (alternate)', (t) => {
     const expected = {width: 768, height: 180, size: 9579, mime: 'video/webm'};
-    const pathAttributes = attributes('test/files/example.alternate.webm');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes(
+        'test/files/example.alternate.webm'
+    );
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.alternate.webm')
     );
 
@@ -344,8 +386,8 @@ test('webm (alternate)', (t) => {
 
 test('tiff (little endian)', (t) => {
     const expected = {width: 1, height: 2, size: 222, mime: 'image/tiff'};
-    const pathAttributes = attributes('test/files/example.tiff');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.tiff');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.tiff')
     );
 
@@ -355,8 +397,8 @@ test('tiff (little endian)', (t) => {
 
 test('tiff (big endian)', (t) => {
     const expected = {width: 1, height: 2, size: 314, mime: 'image/tiff'};
-    const pathAttributes = attributes('test/files/example.be.tiff');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.be.tiff');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.be.tiff')
     );
 
@@ -366,8 +408,10 @@ test('tiff (big endian)', (t) => {
 
 test('xpm', (t) => {
     const expected = {width: 1, height: 2, size: 79, mime: 'image/x-xpixmap'};
-    const pathAttributes = attributes('test/files/example.xpm');
-    const bufferAttributes = attributes(readFileSync('test/files/example.xpm'));
+    const pathAttributes = readMediaAttributes('test/files/example.xpm');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.xpm')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -375,8 +419,10 @@ test('xpm', (t) => {
 
 test('xbm', (t) => {
     const expected = {width: 1, height: 2, size: 106, mime: 'image/x-xbitmap'};
-    const pathAttributes = attributes('test/files/example.xbm');
-    const bufferAttributes = attributes(readFileSync('test/files/example.xbm'));
+    const pathAttributes = readMediaAttributes('test/files/example.xbm');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.xbm')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -389,8 +435,10 @@ test('cel', (t) => {
         size: 40,
         mime: 'application/octet-stream',
     };
-    const pathAttributes = attributes('test/files/example.cel');
-    const bufferAttributes = attributes(readFileSync('test/files/example.cel'));
+    const pathAttributes = readMediaAttributes('test/files/example.cel');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.cel')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -398,8 +446,10 @@ test('cel', (t) => {
 
 test('fit', (t) => {
     const expected = {width: 1, height: 2, size: 5760, mime: 'image/fits'};
-    const pathAttributes = attributes('test/files/example.fit');
-    const bufferAttributes = attributes(readFileSync('test/files/example.fit'));
+    const pathAttributes = readMediaAttributes('test/files/example.fit');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.fit')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -412,8 +462,10 @@ test('hdr', (t) => {
         size: 67,
         mime: 'image/vnd.radiance',
     };
-    const pathAttributes = attributes('test/files/example.hdr');
-    const bufferAttributes = attributes(readFileSync('test/files/example.hdr'));
+    const pathAttributes = readMediaAttributes('test/files/example.hdr');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.hdr')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -421,8 +473,10 @@ test('hdr', (t) => {
 
 test('mp4', (t) => {
     const expected = {width: 2, height: 4, size: 1548, mime: 'video/mp4'};
-    const pathAttributes = attributes('test/files/example.mp4');
-    const bufferAttributes = attributes(readFileSync('test/files/example.mp4'));
+    const pathAttributes = readMediaAttributes('test/files/example.mp4');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.mp4')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -430,8 +484,8 @@ test('mp4', (t) => {
 
 test('mp4 (mp42)', (t) => {
     const expected = {width: 2, height: 4, size: 1580, mime: 'video/mp4'};
-    const pathAttributes = attributes('test/files/example.mp42.mp4');
-    const bufferAttributes = attributes(
+    const pathAttributes = readMediaAttributes('test/files/example.mp42.mp4');
+    const bufferAttributes = readMediaAttributes(
         readFileSync('test/files/example.mp42.mp4')
     );
 
@@ -441,8 +495,10 @@ test('mp4 (mp42)', (t) => {
 
 test('m4v', (t) => {
     const expected = {width: 2, height: 4, size: 1580, mime: 'video/x-m4v'};
-    const pathAttributes = attributes('test/files/example.m4v');
-    const bufferAttributes = attributes(readFileSync('test/files/example.m4v'));
+    const pathAttributes = readMediaAttributes('test/files/example.m4v');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.m4v')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -450,8 +506,10 @@ test('m4v', (t) => {
 
 test('ogv', (t) => {
     const expected = {width: 2, height: 4, size: 3573, mime: 'video/ogg'};
-    const pathAttributes = attributes('test/files/example.ogv');
-    const bufferAttributes = attributes(readFileSync('test/files/example.ogv'));
+    const pathAttributes = readMediaAttributes('test/files/example.ogv');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.ogv')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -464,8 +522,10 @@ test('mkv', (t) => {
         size: 1656,
         mime: 'video/x-matroska',
     };
-    const pathAttributes = attributes('test/files/example.mkv');
-    const bufferAttributes = attributes(readFileSync('test/files/example.mkv'));
+    const pathAttributes = readMediaAttributes('test/files/example.mkv');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.mkv')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -473,8 +533,10 @@ test('mkv', (t) => {
 
 test('avi', (t) => {
     const expected = {width: 2, height: 4, size: 6512, mime: 'video/x-msvideo'};
-    const pathAttributes = attributes('test/files/example.avi');
-    const bufferAttributes = attributes(readFileSync('test/files/example.avi'));
+    const pathAttributes = readMediaAttributes('test/files/example.avi');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.avi')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -482,8 +544,10 @@ test('avi', (t) => {
 
 test('fli', (t) => {
     const expected = {width: 1, height: 2, size: 934, mime: 'video/x-fli'};
-    const pathAttributes = attributes('test/files/example.fli');
-    const bufferAttributes = attributes(readFileSync('test/files/example.fli'));
+    const pathAttributes = readMediaAttributes('test/files/example.fli');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.fli')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -491,8 +555,10 @@ test('fli', (t) => {
 
 test('flc', (t) => {
     const expected = {width: 1, height: 2, size: 934, mime: 'video/x-fli'};
-    const pathAttributes = attributes('test/files/example.flc');
-    const bufferAttributes = attributes(readFileSync('test/files/example.flc'));
+    const pathAttributes = readMediaAttributes('test/files/example.flc');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.flc')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -500,8 +566,10 @@ test('flc', (t) => {
 
 test('mng', (t) => {
     const expected = {width: 100, height: 100, size: 5133, mime: 'video/x-mng'};
-    const pathAttributes = attributes('test/files/example.mng');
-    const bufferAttributes = attributes(readFileSync('test/files/example.mng'));
+    const pathAttributes = readMediaAttributes('test/files/example.mng');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.mng')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -514,8 +582,10 @@ test('flv', (t) => {
         size: 17818,
         mime: 'video/x-flv',
     };
-    const pathAttributes = attributes('test/files/example.flv');
-    const bufferAttributes = attributes(readFileSync('test/files/example.flv'));
+    const pathAttributes = readMediaAttributes('test/files/example.flv');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.flv')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -528,8 +598,10 @@ test('mov', (t) => {
         size: 6156,
         mime: 'video/quicktime',
     };
-    const pathAttributes = attributes('test/files/example.mov');
-    const bufferAttributes = attributes(readFileSync('test/files/example.mov'));
+    const pathAttributes = readMediaAttributes('test/files/example.mov');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.mov')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);
@@ -542,8 +614,10 @@ test('wmv', (t) => {
         size: 19827,
         mime: 'video/x-ms-wmv',
     };
-    const pathAttributes = attributes('test/files/example.wmv');
-    const bufferAttributes = attributes(readFileSync('test/files/example.wmv'));
+    const pathAttributes = readMediaAttributes('test/files/example.wmv');
+    const bufferAttributes = readMediaAttributes(
+        readFileSync('test/files/example.wmv')
+    );
 
     t.like(expected, pathAttributes);
     t.like(pathAttributes, bufferAttributes);

--- a/test/mime-types.mjs
+++ b/test/mime-types.mjs
@@ -1,7 +1,7 @@
 import {readdirSync} from 'fs';
 import test from 'ava';
 import mime from 'mime-types';
-import {attributes} from '../src/index.js';
+import {readMediaAttributes} from '../src/index.js';
 
 readdirSync('test/files')
     .map((name) => {
@@ -10,7 +10,7 @@ readdirSync('test/files')
         return {
             path,
             name,
-            mime: attributes(path).mime,
+            mime: readMediaAttributes(path).mime,
             expected: mime.lookup(path),
         };
     })


### PR DESCRIPTION
- 2.1.5
- BREAKING: rename all `attributes` exports to `readMediaAttributes`
